### PR TITLE
Fix import error

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ class Gravatar extends React.Component {
         const uri = GRAVATAR_URI + md5(this.props.emailAddress) + '?s=' + this.props.size;
         const style = this._calculateStyle();
         return (
-            <View style={[styles.overlay, style]}>
-                <Image source={{uri}} style={[styles.image]} />
+            <View style={[styles.overlay]}>
+                <Image source={{uri}} style={[styles.image, style]} />
             </View>
         );
     }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-import React, {
-    Component,
+import React, { Component } from 'react';
+import {
     StyleSheet,
     View,
     Image


### PR DESCRIPTION
Requiring React API from react-native is now deprecated:

Instead of:

import React, { Component, View } from 'react-native';

you should now:

import React, { Component } from 'react';
import { View } from 'react-native';
