### PR TITLE
Support SSL by default, with a prop override

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,13 +30,9 @@ class Gravatar extends React.Component {
     }
 
     render() {
-        var PROTOCOL = 'https://';
+        const protocol = this.props.secure ? 'https://' : 'http://';
 
-        if (false === this.props.secure) {
-            PROTOCOL = 'http://';
-        }
-
-        const uri = PROTOCOL + GRAVATAR_URI + md5(this.props.emailAddress) + '?s=' + this.props.size;
+        const uri = protocol + GRAVATAR_URI + md5(this.props.emailAddress) + '?s=' + this.props.size;
         const style = this._calculateStyle();
         return (
             <View style={[styles.overlay]}>

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import {
 
 import md5 from 'blueimp-md5';
 
-const GRAVATAR_URI = 'http://www.gravatar.com/avatar/';
+const GRAVATAR_URI = 'www.gravatar.com/avatar/';
 
 class Gravatar extends React.Component {
 
@@ -30,7 +30,13 @@ class Gravatar extends React.Component {
     }
 
     render() {
-        const uri = GRAVATAR_URI + md5(this.props.emailAddress) + '?s=' + this.props.size;
+        var PROTOCOL = 'https://';
+
+        if (false === this.props.secure) {
+            PROTOCOL = 'http://';
+        }
+
+        const uri = PROTOCOL + GRAVATAR_URI + md5(this.props.emailAddress) + '?s=' + this.props.size;
         const style = this._calculateStyle();
         return (
             <View style={[styles.overlay]}>
@@ -49,7 +55,8 @@ Gravatar.propTypes = {
 
 Gravatar.defaultProps = {
     size: 600,
-    mask: 'circle'
+    mask: 'circle',
+    secure: true
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Sets the default protocol to https, but allows override with a
`secure={false}` prop if desired

Fixes #4